### PR TITLE
Add alternative amiga and c64 spellings

### DIFF
--- a/main.py
+++ b/main.py
@@ -33,6 +33,7 @@ MIN_MATCH_SCORE = 90
 
 
 rom_mapping = {
+    "PUAE": "Commodore - Amiga",
     "AMIGA": "Commodore - Amiga",
     "FBN": "FBNeo - Arcade Games",
     "CPC": "Amstrad - CPC",
@@ -40,6 +41,7 @@ rom_mapping = {
     "FIFTYTWOHUNDRED": "Atari - 5200",
     "LYNX": "Atari - Lynx",
     "COLECO": "Coleco - ColecoVision",
+    "C64": "Commodore - 64",
     "COMMODORE": "Commodore - 64",
     "DOS": "DOS",
     "DOOM": "DOOM",


### PR DESCRIPTION
👋 

Using this with NextUI in my trim ui and noticed some of the names for the consoles are different so I added the following:

1.     "C64": "Commodore - 64",
2.     "PUAE": "Commodore - Amiga",

Thank you so much for the App its a live saver